### PR TITLE
Add feature and update site to enable the P3 repository build

### DIFF
--- a/com.opcoach.e34tools.feature/.project
+++ b/com.opcoach.e34tools.feature/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>com.opcoach.e34tools.feature</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.pde.FeatureBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.FeatureNature</nature>
+	</natures>
+</projectDescription>

--- a/com.opcoach.e34tools.feature/build.properties
+++ b/com.opcoach.e34tools.feature/build.properties
@@ -1,0 +1,1 @@
+bin.includes = feature.xml

--- a/com.opcoach.e34tools.feature/feature.xml
+++ b/com.opcoach.e34tools.feature/feature.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feature
+      id="com.opcoach.e34tools.feature"
+      label="e34 Tools Feature"
+      version="1.0.0.qualifier"
+      provider-name="OPCOACH">
+
+   <description url="http://www.example.com/description">
+      [Enter Feature Description here.]
+   </description>
+
+   <copyright url="http://www.example.com/copyright">
+      [Enter Copyright Description here.]
+   </copyright>
+
+   <license url="http://www.example.com/license">
+      [Enter License Description here.]
+   </license>
+
+   <plugin
+         id="com.opcoach.e34.tools"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+</feature>

--- a/com.opcoach.e34tools.updatesite/.project
+++ b/com.opcoach.e34tools.updatesite/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>com.opcoach.e34tools.updatesite</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.pde.UpdateSiteBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.UpdateSiteNature</nature>
+	</natures>
+</projectDescription>

--- a/com.opcoach.e34tools.updatesite/site.xml
+++ b/com.opcoach.e34tools.updatesite/site.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<site>
+   <feature url="features/com.opcoach.e34tools.feature_1.0.0.201403252212.jar" id="com.opcoach.e34tools.feature" version="1.0.0.201403252212">
+      <category name="e34tools"/>
+   </feature>
+   <category-def name="e34tools" label="E34 Tools"/>
+</site>


### PR DESCRIPTION
I kept the same name for the feature and update site projects. Perhaps it will be better to rename it in E34MigrationTools in case of some new plugin with new functionalties are added later.
I didn't define the licence, the copyright and the description in the feature.
